### PR TITLE
Artifact attestation in Docker Workflow hatte keinen Zugang zu Tags

### DIFF
--- a/.github/workflows/publish_docker_image.yml
+++ b/.github/workflows/publish_docker_image.yml
@@ -49,6 +49,6 @@ jobs:
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v1
         with:
-          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          subject-digest: ${{ steps.docker_build.outputs.digest }}  # Verwendung des Digests aus dem Docker Build-Schritt
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}
+          subject-digest: ${{ steps.docker_build.outputs.digest }}
           push-to-registry: true


### PR DESCRIPTION
The artifact attestation in the `publish_docker_image` workflow has been updated to include the version of the image. This ensures that the attestation is accurate and reflects the specific version being pushed to the registry.